### PR TITLE
Deduplication in scheduler

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -27,6 +27,7 @@ class QueryManager {
     required this.link,
     required this.cache,
     this.alwaysRebroadcast = false,
+    bool deduplicatePollers = false,
   }) {
     scheduler = QueryScheduler(
       queryManager: this,

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -31,6 +31,7 @@ class QueryManager {
   }) {
     scheduler = QueryScheduler(
       queryManager: this,
+      deduplicatePollers: deduplicatePollers,
     );
   }
 

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -32,6 +32,7 @@ class GraphQLClient implements GraphQLDataProxy {
           link: link,
           cache: cache,
           alwaysRebroadcast: alwaysRebroadcast,
+          deduplicatePollers: deduplicatePollers,
         );
 
   /// The default [Policies] to set for each client action

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -26,6 +26,7 @@ class GraphQLClient implements GraphQLDataProxy {
     required this.cache,
     DefaultPolicies? defaultPolicies,
     bool alwaysRebroadcast = false,
+    bool deduplicatePollers = false,
   })  : defaultPolicies = defaultPolicies ?? DefaultPolicies(),
         queryManager = QueryManager(
           link: link,

--- a/packages/graphql/lib/src/scheduler/scheduler.dart
+++ b/packages/graphql/lib/src/scheduler/scheduler.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 
+import 'package:collection/collection.dart';
+import 'package:gql_exec/gql_exec.dart';
 import 'package:graphql/src/core/query_manager.dart';
 import 'package:graphql/src/core/query_options.dart';
 import 'package:graphql/src/core/observable_query.dart';
@@ -8,9 +10,11 @@ import 'package:graphql/src/core/observable_query.dart';
 class QueryScheduler {
   QueryScheduler({
     this.queryManager,
-  });
+    bool deduplicatePollers = false,
+  }) : _deduplicatePollers = deduplicatePollers;
 
   QueryManager? queryManager;
+  final bool _deduplicatePollers;
 
   /// Map going from query ids to the [WatchQueryOptions] associated with those queries.
   Map<String, WatchQueryOptions> registeredQueries =
@@ -68,25 +72,81 @@ class QueryScheduler {
       options.pollInterval != null && options.pollInterval! > Duration.zero,
     );
 
+    final existingEntry = _fastestEntryForRequest(options.asRequest);
+    final String? existingQueryId = existingEntry?.key;
+    final Duration? existingInterval = existingEntry?.value.pollInterval;
+
+    // Update or add the query in registeredQueries
     registeredQueries[queryId] = options;
 
-    final interval = options.pollInterval;
+    final Duration interval;
 
-    if (intervalQueries.containsKey(interval)) {
-      intervalQueries[interval]!.add(queryId);
+    if (existingInterval != null && _deduplicatePollers) {
+      if (existingInterval > options.pollInterval!) {
+        // The new one is faster, remove the old one and add the new one
+        intervalQueries[existingInterval]!.remove(existingQueryId);
+        interval = options.pollInterval!;
+      } else {
+        // The new one is slower or the same. Don't add it to the list
+        return;
+      }
     } else {
-      intervalQueries[interval] = Set<String>.of([queryId]);
-
-      _pollingTimers[interval] = Timer.periodic(
-        interval!,
-        (Timer timer) => fetchQueriesOnInterval(timer, interval),
-      );
+      // If there is no existing interval, we'll add the new one
+      interval = options.pollInterval!;
     }
+
+    // Add new query to intervalQueries
+    _addInterval(queryId, interval);
   }
 
   /// Removes the [ObservableQuery] from one of the registered queries.
   /// The fetchQueriesOnInterval will then take care of not firing it anymore.
   void stopPollingQuery(String queryId) {
-    registeredQueries.remove(queryId);
+    final removedQuery = registeredQueries.remove(queryId);
+
+    if (removedQuery == null ||
+        removedQuery.pollInterval != null ||
+        !_deduplicatePollers) {
+      return;
+    }
+
+    // If there is a registered query that has the same `asRequest` as this one
+    // Add the next fastest duration to the intervalQueries
+    final fastestEntry = _fastestEntryForRequest(removedQuery.asRequest);
+    final String? fastestQueryId = fastestEntry?.key;
+    final Duration? fastestInterval = fastestEntry?.value.pollInterval;
+
+    if (fastestQueryId == null || fastestInterval == null) {
+      // There is no other query, return.
+      return;
+    }
+
+    _addInterval(fastestQueryId, fastestInterval);
+  }
+
+  /// Adds a [queryId] to the [intervalQueries] for a specific [interval]
+  /// and starts the timer if it doesn't exist.
+  void _addInterval(String queryId, Duration interval) {
+    final existingSet = intervalQueries[interval];
+    if (existingSet != null) {
+      existingSet.add(queryId);
+    } else {
+      intervalQueries[interval] = {queryId};
+      _pollingTimers[interval] = Timer.periodic(
+          interval, (Timer timer) => fetchQueriesOnInterval(timer, interval));
+    }
+  }
+
+  /// Returns the fastest query that matches the [request] or null if none exists.
+  MapEntry<String, WatchQueryOptions<Object?>>? _fastestEntryForRequest(
+      Request request) {
+    return registeredQueries.entries
+        // All existing queries mapping to the same request.
+        .where((entry) =>
+            entry.value.asRequest == request &&
+            entry.value.pollInterval != null)
+        // Ascending is default (shortest poll interval first)
+        .sortedBy((entry) => entry.value.pollInterval!)
+        .firstOrNull;
   }
 }

--- a/packages/graphql/lib/src/scheduler/scheduler.dart
+++ b/packages/graphql/lib/src/scheduler/scheduler.dart
@@ -105,7 +105,7 @@ class QueryScheduler {
     final removedQuery = registeredQueries.remove(queryId);
 
     if (removedQuery == null ||
-        removedQuery.pollInterval != null ||
+        removedQuery.pollInterval == null ||
         !_deduplicatePollers) {
       return;
     }


### PR DESCRIPTION
### Problem
If you call startPolling 10 times for the same request, it'll start 10 pollers that are all doing the same thing.

### Solution
* Allow consumers to specify if they'd like deduplication (defaults to false for backwards compatibility)
* When a new poller is added, if it's a shorter duration than the previous one for that identical request, it'll update to use the new time
	* If that faster poller is removed, it'll fallback to the next fastest time
	* If all pollers for a request are removed, it doesn't poll

### Testing
```dart
    final friendRequestsObservable = fetch(
      _client.friendRequests(_onMyFriendRequests),
      FetchPolicy.cacheAndNetwork,
    );
    final obs5 = _client.friendRequests(_onMyFriendRequests);
    final obs10 = _client.friendRequests(_onMyFriendRequests);
    final obs3 = _client.friendRequests(_onMyFriendRequests);
    final obs15 = _client.friendRequests(_onMyFriendRequests);

    obs5.startPolling(const Duration(seconds: 5));
    obs10.startPolling(const Duration(seconds: 10));
    obs3.startPolling(const Duration(seconds: 3));
    obs15.startPolling(const Duration(seconds: 15));
    // Should settle at 3 seconds (fastest)

    // Wait 10 seconds to confirm pollers only every 3 seconds
    Future.delayed(const Duration(seconds: 7)).then((_) {
      print('------------------TEST------------------');
      obs3.stopPolling();
      // Duration should now be 5 seconds
    });
    // Confirm it's 5 (should see 3 or 4 of them)
    Future.delayed(const Duration(seconds: 20)).then((_) {
      print('------------------TEST------------------');
      obs5.close();
      // Duration should now be 10 seconds
    });
```